### PR TITLE
feat: add neon tetris game

### DIFF
--- a/game.css
+++ b/game.css
@@ -1,0 +1,27 @@
+body {
+  margin: 0;
+  background: radial-gradient(circle at center, #111, #000);
+  color: #0ff;
+  font-family: 'Courier New', Courier, monospace;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+#ui {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+canvas {
+  border: 2px solid #0ff;
+  background: rgba(0, 0, 0, 0.8);
+  box-shadow: 0 0 20px #0ff;
+}
+
+#info {
+  color: #0ff;
+  text-shadow: 0 0 5px #0ff;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Tetris</title>
+  <link rel="stylesheet" href="game.css" />
+</head>
+<body>
+  <div id="ui">
+    <canvas id="game" width="300" height="600"></canvas>
+    <div id="info">
+      <h1>Neon Tetris</h1>
+      <p>Score: <span id="score">0</span></p>
+      <p>Lines: <span id="lines">0</span></p>
+      <p>Level: <span id="level">1</span></p>
+    </div>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,256 @@
+const canvas = document.getElementById('game');
+const context = canvas.getContext('2d');
+context.scale(30, 30);
+
+const arena = createMatrix(10, 20);
+
+const colors = [
+  null,
+  '#0ff',
+  '#f0f',
+  '#ff0',
+  '#0f0',
+  '#f00',
+  '#00f',
+  '#ff7f00',
+];
+
+const player = {
+  pos: { x: 0, y: 0 },
+  matrix: null,
+  score: 0,
+  lines: 0,
+  level: 1,
+};
+
+function createMatrix(w, h) {
+  const matrix = [];
+  while (h--) {
+    matrix.push(new Array(w).fill(0));
+  }
+  return matrix;
+}
+
+function createPiece(type) {
+  switch (type) {
+    case 'T':
+      return [
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 0, 0],
+      ];
+    case 'O':
+      return [
+        [2, 2],
+        [2, 2],
+      ];
+    case 'L':
+      return [
+        [0, 3, 0],
+        [0, 3, 0],
+        [0, 3, 3],
+      ];
+    case 'J':
+      return [
+        [0, 4, 0],
+        [0, 4, 0],
+        [4, 4, 0],
+      ];
+    case 'I':
+      return [
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+        [0, 5, 0, 0],
+      ];
+    case 'S':
+      return [
+        [0, 6, 6],
+        [6, 6, 0],
+        [0, 0, 0],
+      ];
+    case 'Z':
+      return [
+        [7, 7, 0],
+        [0, 7, 7],
+        [0, 0, 0],
+      ];
+  }
+}
+
+function collide(arena, player) {
+  const [m, o] = [player.matrix, player.pos];
+  for (let y = 0; y < m.length; ++y) {
+    for (let x = 0; x < m[y].length; ++x) {
+      if (m[y][x] !== 0 && (arena[y + o.y] && arena[y + o.y][x + o.x]) !== 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function merge(arena, player) {
+  player.matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        arena[y + player.pos.y][x + player.pos.x] = value;
+      }
+    });
+  });
+}
+
+function rotate(matrix, dir) {
+  for (let y = 0; y < matrix.length; ++y) {
+    for (let x = 0; x < y; ++x) {
+      [matrix[x][y], matrix[y][x]] = [matrix[y][x], matrix[x][y]];
+    }
+  }
+  if (dir > 0) {
+    matrix.forEach((row) => row.reverse());
+  } else {
+    matrix.reverse();
+  }
+}
+
+function playerDrop() {
+  player.pos.y++;
+  if (collide(arena, player)) {
+    player.pos.y--;
+    merge(arena, player);
+    arenaSweep();
+    playerReset();
+  }
+  dropCounter = 0;
+}
+
+function playerMove(dir) {
+  player.pos.x += dir;
+  if (collide(arena, player)) {
+    player.pos.x -= dir;
+  }
+}
+
+function playerReset() {
+  const pieces = 'TJLOSZI';
+  player.matrix = createPiece(pieces[(pieces.length * Math.random()) | 0]);
+  player.pos.y = 0;
+  player.pos.x = ((arena[0].length / 2) | 0) - ((player.matrix[0].length / 2) | 0);
+  if (collide(arena, player)) {
+    arena.forEach((row) => row.fill(0));
+    player.score = 0;
+    player.lines = 0;
+    player.level = 1;
+    dropInterval = 1000;
+  }
+  updateScore();
+}
+
+function playerRotate(dir) {
+  const pos = player.pos.x;
+  let offset = 1;
+  rotate(player.matrix, dir);
+  while (collide(arena, player)) {
+    player.pos.x += offset;
+    offset = -(offset + (offset > 0 ? 1 : -1));
+    if (offset > player.matrix[0].length) {
+      rotate(player.matrix, -dir);
+      player.pos.x = pos;
+      return;
+    }
+  }
+}
+
+function hardDrop() {
+  while (!collide(arena, player)) {
+    player.pos.y++;
+  }
+  player.pos.y--;
+  merge(arena, player);
+  arenaSweep();
+  playerReset();
+  dropCounter = 0;
+}
+
+function arenaSweep() {
+  let rowCount = 1;
+  outer: for (let y = arena.length - 1; y >= 0; --y) {
+    for (let x = 0; x < arena[y].length; ++x) {
+      if (arena[y][x] === 0) {
+        continue outer;
+      }
+    }
+    const row = arena.splice(y, 1)[0].fill(0);
+    arena.unshift(row);
+    ++y;
+
+    player.score += rowCount * 100;
+    player.lines += 1;
+    if (player.lines % 10 === 0) {
+      player.level += 1;
+      dropInterval = Math.max(100, dropInterval - 100);
+    }
+    rowCount *= 2;
+  }
+  updateScore();
+}
+
+function drawMatrix(matrix, offset) {
+  matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        context.fillStyle = colors[value];
+        context.fillRect(x + offset.x, y + offset.y, 1, 1);
+        context.strokeStyle = '#111';
+        context.strokeRect(x + offset.x, y + offset.y, 1, 1);
+      }
+    });
+  });
+}
+
+function draw() {
+  context.fillStyle = '#000';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  drawMatrix(arena, { x: 0, y: 0 });
+  drawMatrix(player.matrix, player.pos);
+}
+
+let dropCounter = 0;
+let dropInterval = 1000;
+let lastTime = 0;
+function update(time = 0) {
+  const delta = time - lastTime;
+  lastTime = time;
+  dropCounter += delta;
+  if (dropCounter > dropInterval) {
+    playerDrop();
+  }
+  draw();
+  requestAnimationFrame(update);
+}
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowLeft') {
+    playerMove(-1);
+  } else if (event.key === 'ArrowRight') {
+    playerMove(1);
+  } else if (event.key === 'ArrowDown') {
+    playerDrop();
+  } else if (event.key === 'ArrowUp' || event.key === 'x' || event.key === 'X') {
+    playerRotate(1);
+  } else if (event.key === 'z' || event.key === 'Z') {
+    playerRotate(-1);
+  } else if (event.key === ' ') {
+    hardDrop();
+  }
+});
+
+function updateScore() {
+  document.getElementById('score').innerText = player.score;
+  document.getElementById('lines').innerText = player.lines;
+  document.getElementById('level').innerText = player.level;
+}
+
+playerReset();
+updateScore();
+update();


### PR DESCRIPTION
## Summary
- add game canvas and score display
- style interface with neon themed CSS
- implement Tetris logic with rotation, hard drop, line clearing and scoring

## Testing
- `node --check main.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a14560847483228f1353893850a4fe